### PR TITLE
chore: fix CI typecheck — drop unused baseUrl/paths from root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["packages/*"]
-    },
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
     "target": "ES2015",


### PR DESCRIPTION
## Summary
PR #106 머지 후 main CI의 `pnpm typecheck`가 다음 에러로 실패:

```
tsconfig.json(3,3): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

CI는 TypeScript 6.x를 사용해 deprecated `baseUrl`을 에러로 표시. 권장 우회옵션 `ignoreDeprecations: "6.0"`은 로컬 TS 5.8.3에서는 유효하지 않은 값(5.8은 `"5.0"`만 허용)이라 버전 호환이 안 됨.

`@/*` path alias가 모든 패키지 src에서 단 한 곳도 사용되지 않으므로(`grep -r '"@/' packages/*/src` → 0건) `baseUrl` + `paths` 자체를 제거하는 것이 가장 깨끗한 해결.

## Test plan
- [x] 로컬 `pnpm typecheck` → 11/11 success
- [x] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)