### PR TITLE
chore: fix CI typecheck for themes and sdui-renderer

### DIFF
--- a/packages/sdui-renderer/src/const.ts
+++ b/packages/sdui-renderer/src/const.ts
@@ -12,6 +12,6 @@ import * as Components from '@redotlabs/ui/only-components';
  *  Typography: Typography,
  * }
  */
-export const COMPONENT_MAP = {
+export const COMPONENT_MAP: typeof Components = {
   ...Components,
 };

--- a/packages/themes/tsconfig.json
+++ b/packages/themes/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
@@ -9,4 +10,4 @@
   },
   "include": ["src/**/*"],
   "exclude": ["dist", "node_modules"]
-} 
+}


### PR DESCRIPTION
## Summary
PR #107 머지 후 main CI typecheck에서 두 가지 새 에러 발생:

### themes
```
src/theme-provider.tsx(49,31): error TS2550: Property 'entries' does not exist on type 'ObjectConstructor'.
  Try changing the 'lib' compiler option to 'es2017' or later.
src/theme-provider.tsx(50,12): error TS7031: Binding element 'key' implicitly has an 'any' type.
```

`Object.entries`는 ES2017+ lib 메서드인데 root tsconfig가 `target: "ES2015"`만 명시하고 `lib`는 추론에 맡김. CI의 더 엄격한 TS가 잡아냄.

→ `packages/themes/tsconfig.json`에 `"lib": ["ES2020", "DOM", "DOM.Iterable"]` 추가. 다른 패키지에 회귀 영향 없도록 themes 패키지로만 한정.

### sdui-renderer
```
src/const.ts(15,14): error TS2742: The inferred type of 'COMPONENT_MAP' cannot be named without a reference to '../node_modules/@redotlabs/ui/dist/pagination/pagination'. This is likely not portable. A type annotation is necessary.
```

PR #106에서 새로 빌드된 `@redotlabs/ui`의 dist가 일부 컴포넌트 타입을 portable하지 않게 export하여 CI의 더 엄격한 타입 검사에서 inferred type을 표현할 수 없다는 에러 발생.

→ `COMPONENT_MAP`에 `typeof Components` 명시적 타입 annotation 추가. `keyof typeof COMPONENT_MAP` 사용처(types.ts)와도 호환.

## Test plan
- [x] 로컬 `pnpm typecheck` → 11/11 success
- [x] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)