### PR TITLE
Ci / Storybook deploy leaves a bot empty commit

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -20,9 +20,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.REDOT_PRIVATE_PAT }}
-          fetch-depth: 0 
+          fetch-depth: 0
+
+      - name: Commit deploy trigger
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git commit --allow-empty -m "cd: trigger deploy $(date +%s)"
 
       - name: Push to deploy repository
         run: |
           git remote add deploy https://redot-dev:${{ secrets.REDOT_PRIVATE_PAT }}@github.com/redot-dev/design-system-deploy.git
-          git push --force deploy main
+          git push --force deploy HEAD:main


### PR DESCRIPTION
## 요약
Storybook 배포 워크플로우(`deploy-storybook.yml`)가 deploy repo로 푸시하기 전에, `app-kcbna`의 배포 워크플로우처럼 **봇 계정으로 빈 커밋**을 남기도록 합니다. 이렇게 하면 deploy repo가 항상 새 트리거 커밋을 받아 배포가 확실히 걸립니다.

## 변경
- Checkout과 Push 사이에 `Commit deploy trigger` 단계 추가
  - `git config user.name "github-actions"` / `user.email "actions@github.com"`
  - `git commit --allow-empty -m "cd: trigger deploy $(date +%s)"`
- push를 `deploy main` → `deploy HEAD:main` 으로 변경 (kcbna 패턴과 동일)

## 참고
- kcbna `deploy.yml`의 `Commit deploy trigger` 단계를 그대로 차용