### PR TITLE
Chore / Remove unused framer-motion from ui

### DIFF
--- a/.changeset/ui-remove-framer-motion.md
+++ b/.changeset/ui-remove-framer-motion.md
@@ -1,0 +1,5 @@
+---
+'@redotlabs/ui': patch
+---
+
+Remove the unused `framer-motion` dependency from the ui package — it is no longer imported by any component.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,7 +53,6 @@
     "@radix-ui/react-select": "^2.3.0",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
-    "framer-motion": "^12.23.24",
     "react-day-picker": "^9.11.1",
     "sonner": "^2.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,9 +246,6 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
-      framer-motion:
-        specifier: ^12.23.24
-        version: 12.23.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -2698,20 +2695,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  framer-motion@12.23.24:
-    resolution: {integrity: sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -3281,12 +3264,6 @@ packages:
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
-
-  motion-dom@12.23.23:
-    resolution: {integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==}
-
-  motion-utils@12.23.6:
-    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -6602,15 +6579,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  framer-motion@12.23.24(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      motion-dom: 12.23.23
-      motion-utils: 12.23.6
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -7148,12 +7116,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
-
-  motion-dom@12.23.23:
-    dependencies:
-      motion-utils: 12.23.6
-
-  motion-utils@12.23.6: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## 요약
`@redotlabs/ui`에서 더 이상 사용되지 않는 `framer-motion` 의존성을 제거합니다.

## 배경
develop의 `packages/ui` 어떤 소스(스토리 포함)도 `framer-motion`을 import하지 않습니다 — `package.json`에만 죽은 의존성으로 남아 있었습니다.

## 변경
- `packages/ui/package.json`에서 `framer-motion` 제거
- `pnpm-lock.yaml` 재생성
- patch 체인지셋 추가

## 검증
- 추적 파일 기준 `@redotlabs/ui` typecheck 통과
- ui 소스 전역에 framer-motion 사용 없음 확인

## 참고
- 기존 `refactor/ui/unuse-framer-motion` 브랜치가 동일 목적이나 develop보다 19커밋 뒤처진 **stale** 상태이고 옛 `select.tsx`를 47줄 수정해 충돌 위험이 있어, 그 브랜치 대신 소스 무변경의 깔끔한 제거로 진행했습니다. (해당 브랜치는 닫는 것을 권장)