### PR TITLE
ci: storybook k8s 이미지 빌드 (redot-storybook GHCR)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+**/node_modules
+storybook-static
+**/dist
+.git
+.github
+.turbo
+**/.turbo
+*.log
+.env
+.env.*

--- a/.github/workflows/ci-k8s.yml
+++ b/.github/workflows/ci-k8s.yml
@@ -1,0 +1,59 @@
+name: CI (k8s image)
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & push (linux/arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          # PR: 빌드 검증만 (push X). main push: GHCR push.
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/redotlabs/redot-storybook:${{ github.sha }}
+            ghcr.io/redotlabs/redot-storybook:main
+          labels: |
+            org.opencontainers.image.source=https://github.com/redotlabs/design-system
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  bump-manifest:
+    needs: build-and-push
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ryxxn/homelab-k3s
+          token: ${{ secrets.HOMELAB_REPO_TOKEN }}
+      - name: Bump image tag & push
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          yq -i '(select(.kind == "Deployment" and .metadata.name == "redot-storybook").spec.template.spec.containers[0].image) = "ghcr.io/redotlabs/redot-storybook:" + strenv(SHA)' redot/storybook.yaml
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add redot/storybook.yaml
+          git diff --cached --quiet || git commit -m "deploy(redot-storybook): ${SHA}"
+          git push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# storybook static 빌드 → nginx 정적 서빙 (redot-storybook)
+# ---- builder ----
+FROM node:20-alpine AS builder
+RUN corepack enable && corepack prepare pnpm@10.6.1 --activate
+WORKDIR /app
+
+COPY . .
+RUN pnpm install --frozen-lockfile
+RUN pnpm build-storybook          # → storybook-static/
+
+# ---- runner ----
+FROM nginx:alpine
+COPY --from=builder /app/storybook-static /usr/share/nginx/html
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 COPY . .
 RUN pnpm install --frozen-lockfile
+RUN pnpm build                    # turbo build @redotlabs/* → 워크스페이스 패키지 dist(tokens 등)
 RUN pnpm build-storybook          # → storybook-static/
 
 # ---- runner ----

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # storybook static 빌드 → nginx 정적 서빙 (redot-storybook)
 # ---- builder ----
 FROM node:20-alpine AS builder
+RUN apk add --no-cache bash git   # @redotlabs/fonts build.sh 가 bash 필요 (alpine 기본 미포함)
 RUN corepack enable && corepack prepare pnpm@10.6.1 --activate
 WORKDIR /app
 


### PR DESCRIPTION
## 요약
redot-storybook을 GHCR로 이전하기 위한 CI 추가 (홈랩 k8s 배포용).

- `Dockerfile`: 멀티스테이지(pnpm build-storybook → nginx 정적 서빙), 네이티브 arm64
- `.github/workflows/ci-k8s.yml`: **PR=빌드 검증만**, main push=GHCR push + homelab-k3s write-back → ArgoCD 배포
- 기존 `deploy-storybook.yml`(다른 레포로 push)과 무관, 별도 잡

## 검증
이 PR의 build 잡이 통과하면 storybook 빌드가 arm64에서 정상. merge하면 실제 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)